### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ For example, to install the `rlhf` skill:
 $skill-installer install https://github.com/itsmostafa/aws-agent-skills/rlhf
 ```
 
+### sk
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, etc...).
+
+```bash
+sk pkg add claude-plugin aws-agent-skills@itsmostafa/aws-agent-skills
+sk sync
+```
+
 ## Available Skills
 
 | Skill | Description |


### PR DESCRIPTION
`sk` is a universal package manager (works across all coding agents), handles updates, etc.. (npm/cargo for agents).

would you be open to adding this?